### PR TITLE
Retry if failure

### DIFF
--- a/pypx800/__init__.py
+++ b/pypx800/__init__.py
@@ -24,8 +24,8 @@ class IPX800:
         request_retries = self.retries
         params_with_api = {"key": self.api_key}
         params_with_api.update(params)
-        r = requests.get(self._api_url, params=params_with_api, timeout=2)
         while request_retries > 0:
+            r = requests.get(self._api_url, params=params_with_api, timeout=2)
             r.raise_for_status()
             content = r.json()
             result = content.get("status", None)
@@ -42,8 +42,8 @@ class IPX800:
 
     def _request_cgi(self, params):
         request_retries = self.retries
-        r = requests.get(self._cgi_url, params=params, timeout=2)
         while request_retries > 0:
+            r = requests.get(self._cgi_url, params=params, timeout=2)
             r.raise_for_status()
             content = r.text
             if "Success" in content:

--- a/pypx800/__init__.py
+++ b/pypx800/__init__.py
@@ -1,5 +1,6 @@
 import collections
 import requests
+from random import randrange
 from time import sleep
 
 DEFAULT_TRANSITION = 500
@@ -32,7 +33,7 @@ class IPX800:
             if result == "Success":
                 return content
             request_retries -= 1
-            sleep(1)
+            sleep(randrange(200, 800)/1000)
             pass
         raise Exception(
             "IPX800 api request error, url: %s`r%s",
@@ -49,7 +50,7 @@ class IPX800:
             if "Success" in content:
                 return content
             request_retries -= 1
-            sleep(1)
+            sleep(randrange(200, 800)/1000)
             pass
         raise Exception(
             "IPX800 cgi request error, url: %s`r%s",


### PR DESCRIPTION
Bonjour,

Durant mes tests, j'ai pu observer un bug : La requête n'était pas exécutée à nouveau lorsqu'il y avait une erreur. De ce fait, c'était toujours la première erreur qui était remontée. J'ai donc placé le code qui envoi la requête à l'IPX à l'intérieur de la boucle.

De plus, je pense qu'il peut être intéressant de rendre aléatoire le temps avant de recommencer la requête. Si deux erreurs se produisent au même moment, elles sont relancées à des instants différents, ce qui peut permettre d'éviter de nouvelles erreurs.